### PR TITLE
fix(dev-server): move global style in app.vue

### DIFF
--- a/src/app/App.vue
+++ b/src/app/App.vue
@@ -28,3 +28,7 @@ export default defineComponent({
   },
 })
 </script>
+
+<style lang="scss">
+  @import url("./assets/scss/index.scss");
+</style>

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -7,8 +7,6 @@ import { Pinia } from 'pinia'
 import createI18n from './i18n'
 import { AppKoaContext } from '@/typings/ssr'
 
-import './assets/scss/index.scss'
-
 interface CreateAppArgs {
   serverContext?: AppKoaContext
   postCreateStore: (_store?: Pinia) => Promise<void>


### PR DESCRIPTION
Vite n'interprète pas les scss qui sont importés dans le app.ts, du coup je l'ai déplacé dans le App.vue...

J'ai également vue que les styles qu'on force côté server en dev-server se retrouvent en doublon avec les styles qui sont chargés normalement côté client. On verra dans un second temps, il faut qu'on suive les évolutions de vite.